### PR TITLE
C++: Alert suppresion through single-line /* */ style comments

### DIFF
--- a/cpp/ql/src/AlertSuppression.ql
+++ b/cpp/ql/src/AlertSuppression.ql
@@ -10,12 +10,25 @@ import cpp
 /**
  * An alert suppression comment.
  */
-class SuppressionComment extends CppStyleComment {
+class SuppressionComment extends Comment {
   string annotation;
   string text;
 
   SuppressionComment() {
-    text = getContents().suffix(2) and
+    (
+      this instanceof CppStyleComment and
+      // strip the beginning slashes
+      text = getContents().suffix(2)
+      or
+      this instanceof CStyleComment and
+      // strip both the beginning /* and the end */ the comment
+      exists(string text0 |
+        text0 = getContents().suffix(2) and
+        text = text0.prefix(text0.length() - 2)
+      ) and
+      // The /* */ comment must be a single-line comment
+      not text.matches("%\n%")
+    ) and
     (
       // match `lgtm[...]` anywhere in the comment
       annotation = text.regexpFind("(?i)\\blgtm\\s*\\[[^\\]]*\\]", _, _)

--- a/cpp/ql/test/library-tests/dataflow/fields/E.cpp
+++ b/cpp/ql/test/library-tests/dataflow/fields/E.cpp
@@ -1,0 +1,34 @@
+class buf
+{
+public:
+    char *buffer;
+};
+
+class packet
+{
+public:
+    buf data;
+};
+
+typedef long ssize_t;
+
+ssize_t argument_source(void *buf);
+
+void sink(char *b);
+
+void handlePacket(packet *p)
+{
+    sink(p->data.buffer);
+}
+
+void f(buf* b)
+{
+    char *raw;
+    packet p;
+    argument_source(raw);
+    argument_source(b->buffer);
+    argument_source(p.data.buffer);
+    sink(raw);
+    sink(b->buffer);
+    handlePacket(&p);
+}

--- a/cpp/ql/test/library-tests/dataflow/fields/flow.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/flow.expected
@@ -122,6 +122,17 @@ edges
 | D.cpp:64:10:64:17 | boxfield [box, elem] | D.cpp:64:20:64:22 | box [elem] |
 | D.cpp:64:10:64:17 | this [boxfield, box, ... (3)] | D.cpp:64:10:64:17 | boxfield [box, elem] |
 | D.cpp:64:20:64:22 | box [elem] | D.cpp:64:25:64:28 | elem |
+| E.cpp:19:27:19:27 | p [data, buffer] | E.cpp:21:10:21:10 | p [data, buffer] |
+| E.cpp:21:10:21:10 | p [data, buffer] | E.cpp:21:13:21:16 | data [buffer] |
+| E.cpp:21:13:21:16 | data [buffer] | E.cpp:21:18:21:23 | buffer |
+| E.cpp:28:21:28:23 | ref arg raw | E.cpp:31:10:31:12 | raw |
+| E.cpp:29:21:29:21 | b [post update] [buffer] | E.cpp:32:10:32:10 | b [buffer] |
+| E.cpp:29:24:29:29 | ref arg buffer | E.cpp:29:21:29:21 | b [post update] [buffer] |
+| E.cpp:30:21:30:21 | p [post update] [data, buffer] | E.cpp:33:18:33:19 | & ... [data, buffer] |
+| E.cpp:30:23:30:26 | data [post update] [buffer] | E.cpp:30:21:30:21 | p [post update] [data, buffer] |
+| E.cpp:30:28:30:33 | ref arg buffer | E.cpp:30:23:30:26 | data [post update] [buffer] |
+| E.cpp:32:10:32:10 | b [buffer] | E.cpp:32:13:32:18 | buffer |
+| E.cpp:33:18:33:19 | & ... [data, buffer] | E.cpp:19:27:19:27 | p [data, buffer] |
 | aliasing.cpp:9:3:9:3 | s [post update] [m1] | aliasing.cpp:25:17:25:19 | ref arg & ... [m1] |
 | aliasing.cpp:9:3:9:22 | ... = ... | aliasing.cpp:9:3:9:3 | s [post update] [m1] |
 | aliasing.cpp:9:11:9:20 | call to user_input | aliasing.cpp:9:3:9:22 | ... = ... |
@@ -378,6 +389,20 @@ nodes
 | D.cpp:64:10:64:17 | this [boxfield, box, ... (3)] | semmle.label | this [boxfield, box, ... (3)] |
 | D.cpp:64:20:64:22 | box [elem] | semmle.label | box [elem] |
 | D.cpp:64:25:64:28 | elem | semmle.label | elem |
+| E.cpp:19:27:19:27 | p [data, buffer] | semmle.label | p [data, buffer] |
+| E.cpp:21:10:21:10 | p [data, buffer] | semmle.label | p [data, buffer] |
+| E.cpp:21:13:21:16 | data [buffer] | semmle.label | data [buffer] |
+| E.cpp:21:18:21:23 | buffer | semmle.label | buffer |
+| E.cpp:28:21:28:23 | ref arg raw | semmle.label | ref arg raw |
+| E.cpp:29:21:29:21 | b [post update] [buffer] | semmle.label | b [post update] [buffer] |
+| E.cpp:29:24:29:29 | ref arg buffer | semmle.label | ref arg buffer |
+| E.cpp:30:21:30:21 | p [post update] [data, buffer] | semmle.label | p [post update] [data, buffer] |
+| E.cpp:30:23:30:26 | data [post update] [buffer] | semmle.label | data [post update] [buffer] |
+| E.cpp:30:28:30:33 | ref arg buffer | semmle.label | ref arg buffer |
+| E.cpp:31:10:31:12 | raw | semmle.label | raw |
+| E.cpp:32:10:32:10 | b [buffer] | semmle.label | b [buffer] |
+| E.cpp:32:13:32:18 | buffer | semmle.label | buffer |
+| E.cpp:33:18:33:19 | & ... [data, buffer] | semmle.label | & ... [data, buffer] |
 | aliasing.cpp:9:3:9:3 | s [post update] [m1] | semmle.label | s [post update] [m1] |
 | aliasing.cpp:9:3:9:22 | ... = ... | semmle.label | ... = ... |
 | aliasing.cpp:9:11:9:20 | call to user_input | semmle.label | call to user_input |
@@ -532,6 +557,9 @@ nodes
 | D.cpp:22:25:22:31 | call to getElem | D.cpp:42:15:42:24 | new | D.cpp:22:25:22:31 | call to getElem | call to getElem flows from $@ | D.cpp:42:15:42:24 | new | new |
 | D.cpp:22:25:22:31 | call to getElem | D.cpp:49:15:49:24 | new | D.cpp:22:25:22:31 | call to getElem | call to getElem flows from $@ | D.cpp:49:15:49:24 | new | new |
 | D.cpp:64:25:64:28 | elem | D.cpp:56:15:56:24 | new | D.cpp:64:25:64:28 | elem | elem flows from $@ | D.cpp:56:15:56:24 | new | new |
+| E.cpp:21:18:21:23 | buffer | E.cpp:30:28:30:33 | ref arg buffer | E.cpp:21:18:21:23 | buffer | buffer flows from $@ | E.cpp:30:28:30:33 | ref arg buffer | ref arg buffer |
+| E.cpp:31:10:31:12 | raw | E.cpp:28:21:28:23 | ref arg raw | E.cpp:31:10:31:12 | raw | raw flows from $@ | E.cpp:28:21:28:23 | ref arg raw | ref arg raw |
+| E.cpp:32:13:32:18 | buffer | E.cpp:29:24:29:29 | ref arg buffer | E.cpp:32:13:32:18 | buffer | buffer flows from $@ | E.cpp:29:24:29:29 | ref arg buffer | ref arg buffer |
 | aliasing.cpp:29:11:29:12 | m1 | aliasing.cpp:9:11:9:20 | call to user_input | aliasing.cpp:29:11:29:12 | m1 | m1 flows from $@ | aliasing.cpp:9:11:9:20 | call to user_input | call to user_input |
 | aliasing.cpp:30:11:30:12 | m1 | aliasing.cpp:13:10:13:19 | call to user_input | aliasing.cpp:30:11:30:12 | m1 | m1 flows from $@ | aliasing.cpp:13:10:13:19 | call to user_input | call to user_input |
 | aliasing.cpp:62:14:62:15 | m1 | aliasing.cpp:60:11:60:20 | call to user_input | aliasing.cpp:62:14:62:15 | m1 | m1 flows from $@ | aliasing.cpp:60:11:60:20 | call to user_input | call to user_input |

--- a/cpp/ql/test/library-tests/dataflow/fields/flow.ql
+++ b/cpp/ql/test/library-tests/dataflow/fields/flow.ql
@@ -14,6 +14,11 @@ class Conf extends Configuration {
     src.asExpr() instanceof NewExpr
     or
     src.asExpr().(Call).getTarget().hasName("user_input")
+    or
+    exists(FunctionCall fc |
+      fc.getAnArgument() = src.asDefiningArgument() and
+      fc.getTarget().hasName("argument_source")
+    )
   }
 
   override predicate isSink(Node sink) {

--- a/cpp/ql/test/query-tests/AlertSuppression/AlertSuppression.expected
+++ b/cpp/ql/test/query-tests/AlertSuppression/AlertSuppression.expected
@@ -8,6 +8,7 @@
 | tst.c:8:1:8:18 | // lgtm: blah blah |  lgtm: blah blah | lgtm | tst.c:8:1:8:18 | // lgtm: blah blah |
 | tst.c:9:1:9:32 | // lgtm blah blah #falsepositive |  lgtm blah blah #falsepositive | lgtm | tst.c:9:1:9:32 | // lgtm blah blah #falsepositive |
 | tst.c:10:1:10:39 | //lgtm  [js/invocation-of-non-function] | lgtm  [js/invocation-of-non-function] | lgtm  [js/invocation-of-non-function] | tst.c:10:1:10:39 | //lgtm  [js/invocation-of-non-function] |
+| tst.c:11:1:11:10 | /* lgtm */ |  lgtm  | lgtm | tst.c:11:1:11:10 | /* lgtm */ |
 | tst.c:12:1:12:9 | // lgtm[] |  lgtm[] | lgtm[] | tst.c:12:1:12:9 | // lgtm[] |
 | tst.c:14:1:14:6 | //lgtm | lgtm | lgtm | tst.c:14:1:14:6 | //lgtm |
 | tst.c:15:1:15:7 | //\tlgtm | \tlgtm | lgtm | tst.c:15:1:15:7 | //\tlgtm |
@@ -22,6 +23,10 @@
 | tst.c:27:1:27:70 | // lgtm[js/debugger-statement] and lgtm[js/invocation-of-non-function] |  lgtm[js/debugger-statement] and lgtm[js/invocation-of-non-function] | lgtm[js/invocation-of-non-function] | tst.c:27:1:27:70 | // lgtm[js/debugger-statement] and lgtm[js/invocation-of-non-function] |
 | tst.c:28:1:28:36 | // lgtm[js/debugger-statement]; lgtm |  lgtm[js/debugger-statement]; lgtm | lgtm | tst.c:28:1:28:36 | // lgtm[js/debugger-statement]; lgtm |
 | tst.c:28:1:28:36 | // lgtm[js/debugger-statement]; lgtm |  lgtm[js/debugger-statement]; lgtm | lgtm[js/debugger-statement] | tst.c:28:1:28:36 | // lgtm[js/debugger-statement]; lgtm |
+| tst.c:29:1:29:12 | /* lgtm[] */ |  lgtm[]  | lgtm[] | tst.c:29:1:29:12 | /* lgtm[] */ |
+| tst.c:30:1:30:41 | /* lgtm[js/invocation-of-non-function] */ |  lgtm[js/invocation-of-non-function]  | lgtm[js/invocation-of-non-function] | tst.c:30:1:30:41 | /* lgtm[js/invocation-of-non-function] */ |
+| tst.c:36:1:36:55 | /* lgtm[@tag:nullness,js/invocation-of-non-function] */ |  lgtm[@tag:nullness,js/invocation-of-non-function]  | lgtm[@tag:nullness,js/invocation-of-non-function] | tst.c:36:1:36:55 | /* lgtm[@tag:nullness,js/invocation-of-non-function] */ |
+| tst.c:37:1:37:25 | /* lgtm[@tag:nullness] */ |  lgtm[@tag:nullness]  | lgtm[@tag:nullness] | tst.c:37:1:37:25 | /* lgtm[@tag:nullness] */ |
 | tstWindows.c:1:12:1:18 | // lgtm |  lgtm | lgtm | tstWindows.c:1:1:1:18 | // lgtm |
 | tstWindows.c:2:1:2:30 | // lgtm[js/debugger-statement] |  lgtm[js/debugger-statement] | lgtm[js/debugger-statement] | tstWindows.c:2:1:2:30 | // lgtm[js/debugger-statement] |
 | tstWindows.c:3:1:3:61 | // lgtm[js/debugger-statement, js/invocation-of-non-function] |  lgtm[js/debugger-statement, js/invocation-of-non-function] | lgtm[js/debugger-statement, js/invocation-of-non-function] | tstWindows.c:3:1:3:61 | // lgtm[js/debugger-statement, js/invocation-of-non-function] |
@@ -32,6 +37,7 @@
 | tstWindows.c:8:1:8:18 | // lgtm: blah blah |  lgtm: blah blah | lgtm | tstWindows.c:8:1:8:18 | // lgtm: blah blah |
 | tstWindows.c:9:1:9:32 | // lgtm blah blah #falsepositive |  lgtm blah blah #falsepositive | lgtm | tstWindows.c:9:1:9:32 | // lgtm blah blah #falsepositive |
 | tstWindows.c:10:1:10:39 | //lgtm  [js/invocation-of-non-function] | lgtm  [js/invocation-of-non-function] | lgtm  [js/invocation-of-non-function] | tstWindows.c:10:1:10:39 | //lgtm  [js/invocation-of-non-function] |
+| tstWindows.c:11:1:11:10 | /* lgtm */ |  lgtm  | lgtm | tstWindows.c:11:1:11:10 | /* lgtm */ |
 | tstWindows.c:12:1:12:9 | // lgtm[] |  lgtm[] | lgtm[] | tstWindows.c:12:1:12:9 | // lgtm[] |
 | tstWindows.c:14:1:14:6 | //lgtm | lgtm | lgtm | tstWindows.c:14:1:14:6 | //lgtm |
 | tstWindows.c:15:1:15:7 | //\tlgtm | \tlgtm | lgtm | tstWindows.c:15:1:15:7 | //\tlgtm |
@@ -46,3 +52,7 @@
 | tstWindows.c:27:1:27:70 | // lgtm[js/debugger-statement] and lgtm[js/invocation-of-non-function] |  lgtm[js/debugger-statement] and lgtm[js/invocation-of-non-function] | lgtm[js/invocation-of-non-function] | tstWindows.c:27:1:27:70 | // lgtm[js/debugger-statement] and lgtm[js/invocation-of-non-function] |
 | tstWindows.c:28:1:28:36 | // lgtm[js/debugger-statement]; lgtm |  lgtm[js/debugger-statement]; lgtm | lgtm | tstWindows.c:28:1:28:36 | // lgtm[js/debugger-statement]; lgtm |
 | tstWindows.c:28:1:28:36 | // lgtm[js/debugger-statement]; lgtm |  lgtm[js/debugger-statement]; lgtm | lgtm[js/debugger-statement] | tstWindows.c:28:1:28:36 | // lgtm[js/debugger-statement]; lgtm |
+| tstWindows.c:29:1:29:12 | /* lgtm[] */ |  lgtm[]  | lgtm[] | tstWindows.c:29:1:29:12 | /* lgtm[] */ |
+| tstWindows.c:30:1:30:41 | /* lgtm[js/invocation-of-non-function] */ |  lgtm[js/invocation-of-non-function]  | lgtm[js/invocation-of-non-function] | tstWindows.c:30:1:30:41 | /* lgtm[js/invocation-of-non-function] */ |
+| tstWindows.c:36:1:36:55 | /* lgtm[@tag:nullness,js/invocation-of-non-function] */ |  lgtm[@tag:nullness,js/invocation-of-non-function]  | lgtm[@tag:nullness,js/invocation-of-non-function] | tstWindows.c:36:1:36:55 | /* lgtm[@tag:nullness,js/invocation-of-non-function] */ |
+| tstWindows.c:37:1:37:25 | /* lgtm[@tag:nullness] */ |  lgtm[@tag:nullness]  | lgtm[@tag:nullness] | tstWindows.c:37:1:37:25 | /* lgtm[@tag:nullness] */ |

--- a/cpp/ql/test/query-tests/AlertSuppression/tst.c
+++ b/cpp/ql/test/query-tests/AlertSuppression/tst.c
@@ -26,3 +26,12 @@ int x = 0; // lgtm
 // LGTM[js/debugger-statement]
 // lgtm[js/debugger-statement] and lgtm[js/invocation-of-non-function]
 // lgtm[js/debugger-statement]; lgtm
+/* lgtm[] */
+/* lgtm[js/invocation-of-non-function] */
+/* lgtm
+*/
+/* lgtm
+
+*/
+/* lgtm[@tag:nullness,js/invocation-of-non-function] */
+/* lgtm[@tag:nullness] */

--- a/cpp/ql/test/query-tests/AlertSuppression/tstWindows.c
+++ b/cpp/ql/test/query-tests/AlertSuppression/tstWindows.c
@@ -26,3 +26,12 @@ int x = 0; // lgtm
 // LGTM[js/debugger-statement]
 // lgtm[js/debugger-statement] and lgtm[js/invocation-of-non-function]
 // lgtm[js/debugger-statement]; lgtm
+/* lgtm[] */
+/* lgtm[js/invocation-of-non-function] */
+/* lgtm
+*/
+/* lgtm
+
+*/
+/* lgtm[@tag:nullness,js/invocation-of-non-function] */
+/* lgtm[@tag:nullness] */


### PR DESCRIPTION
Adds support for single-line /* */ style comments for alert suppression, as discussed in https://jira.semmle.com/browse/CPP-474